### PR TITLE
hotfix carrousel-album

### DIFF
--- a/components/Feed/Feedei.tsx
+++ b/components/Feed/Feedei.tsx
@@ -29,7 +29,7 @@ export default function Feedei() {
   return (
     <div className={styles.feed_Container}>
       {IfeedList?.map((item,key) => {
-        return (
+        return item.media_type!=="CAROUSEL_ALBUM"?(
           <div key = {key} className={styles.feed_Item}>
             <a href="https://instagram.com/compet.cefet" target="_blank" className={styles.link}>
               <PostHeader
@@ -42,7 +42,7 @@ export default function Feedei() {
               <PostContent {...item}></PostContent>
             </a>
           </div>
-        );
+        ):<></>
       })}
     </div>
   );


### PR DESCRIPTION
Aqui fiz uma pequena alteração pra remover os elementos do tipo carrousel-album do instagram-feed enquanto ainda não é atribuido a ele nenhum componente especializado.